### PR TITLE
Add parser tests using multi-words

### DIFF
--- a/ags3/auto-test/Game.agf
+++ b/ags3/auto-test/Game.agf
@@ -1001,6 +1001,46 @@
           <Word>kill</Word>
           <WordGroup>13</WordGroup>
         </TextParserWord>
+        <TextParserWord>
+          <Type>Normal</Type>
+          <Word xml:space="preserve">red key</Word>
+          <WordGroup>14</WordGroup>
+        </TextParserWord>
+        <TextParserWord>
+          <Type>Normal</Type>
+          <Word xml:space="preserve">blue key</Word>
+          <WordGroup>15</WordGroup>
+        </TextParserWord>
+        <TextParserWord>
+          <Type>Normal</Type>
+          <Word>stone</Word>
+          <WordGroup>16</WordGroup>
+        </TextParserWord>
+        <TextParserWord>
+          <Type>Normal</Type>
+          <Word>hammer</Word>
+          <WordGroup>17</WordGroup>
+        </TextParserWord>
+        <TextParserWord>
+          <Type>Normal</Type>
+          <Word xml:space="preserve">stone hammer</Word>
+          <WordGroup>18</WordGroup>
+        </TextParserWord>
+        <TextParserWord>
+          <Type>Normal</Type>
+          <Word>key</Word>
+          <WordGroup>19</WordGroup>
+        </TextParserWord>
+        <TextParserWord>
+          <Type>Normal</Type>
+          <Word>red</Word>
+          <WordGroup>20</WordGroup>
+        </TextParserWord>
+        <TextParserWord>
+          <Type>Normal</Type>
+          <Word>blue-key</Word>
+          <WordGroup>15</WordGroup>
+        </TextParserWord>
       </Words>
     </TextParser>
     <Characters>

--- a/ags3/auto-test/test-parser.asc
+++ b/ags3/auto-test/test-parser.asc
@@ -161,7 +161,7 @@ void TestParser()
     tap.ok(Parser.Said(saidWords), "Parser.Said test with multi-word synonym 'blue-key' (7)");
     Parser.ParseText("take blue-key");
     tap.ok(Parser.Said(saidWords), "Parser.Said test with multi-word synonym 'blue-key' (8)");
-}
+  }
 
   // Test Parser.Said with one multi-word
   {

--- a/ags3/auto-test/test-parser.asc
+++ b/ags3/auto-test/test-parser.asc
@@ -1,7 +1,26 @@
 // Test Parser Module Script
 int GetTestParserCount()
 {
-  return 12;
+  return 12 + 14 /* prefixed tests */ + 6 /* synonyms */ + 48 /* one multi-word */ + 32 /* two multi-words */;
+}
+
+void TestParserSaid(const string saidWords, const string inputText, int expectedResult)
+{
+    Parser.ParseText(inputText);
+    String testName = String.Format("TestParserSaid: Said() '%s' with ParseText() '%s' should be %d",  saidWords, inputText, expectedResult);
+
+    if(expectedResult)
+      tap.ok(Parser.Said(saidWords), testName);
+    else
+      tap.nok(Parser.Said(saidWords), testName);
+
+    // test with extra content at the end
+    String extendedText = String.Format("%s rol", inputText);
+    Parser.ParseText(extendedText);
+    if(expectedResult)
+      tap.ok(Parser.Said(saidWords), testName);
+    else
+      tap.nok(Parser.Said(saidWords), testName);
 }
 
 void TestParser()
@@ -66,6 +85,139 @@ void TestParser()
     String unknownWord = Parser.SaidUnknownWord();
     tap.is(unknownWord, "badword", "Parser.SaidUnknownWord test");
   }
+  
+  // Test Parser.Said with prefixed words
+  {
+    String saidWords = "take hammer,stone";
+
+    Parser.ParseText("take hammer");
+    tap.ok(Parser.Said(saidWords), "Parser.Said test with prefixed words 'stone hammer' (1)");
+    Parser.ParseText("take stone");
+    tap.ok(Parser.Said(saidWords), "Parser.Said test with prefixed words 'stone hammer' (2)");
+    Parser.ParseText("take stone hammer");
+    tap.nok(Parser.Said(saidWords), "Parser.Said test with prefixed words 'stone hammer' (3)");
+
+    saidWords = "take hammer,stone hammer";
+
+    Parser.ParseText("take hammer");
+    tap.ok(Parser.Said(saidWords), "Parser.Said test with prefixed words 'stone hammer' (4)");
+    Parser.ParseText("take stone");
+    tap.nok(Parser.Said(saidWords), "Parser.Said test with prefixed words 'stone hammer' (5)");
+    Parser.ParseText("take stone hammer");
+    tap.ok(Parser.Said(saidWords), "Parser.Said test with prefixed words 'stone hammer' (6)");
+    Parser.ParseText("take hammer hammer");
+    tap.nok(Parser.Said(saidWords), "Parser.Said test with prefixed words 'stone hammer' (7)");
+
+    saidWords = "take hammer,stone [hammer]";
+
+    Parser.ParseText("take hammer");
+    tap.ok(Parser.Said(saidWords), "Parser.Said test with prefixed words 'stone hammer' (8)");
+    Parser.ParseText("take stone");
+    tap.ok(Parser.Said(saidWords), "Parser.Said test with prefixed words 'stone hammer' (9)");
+    Parser.ParseText("take stone hammer");
+    tap.nok(Parser.Said(saidWords), "Parser.Said test with prefixed words 'stone hammer' (10)");
+    Parser.ParseText("take hammer hammer");
+    tap.ok(Parser.Said(saidWords), "Parser.Said test with prefixed words 'stone hammer' (11)");
+
+    saidWords = "take stone hammer,hammer";
+
+    Parser.ParseText("take hammer");
+    tap.ok(Parser.Said(saidWords), "Parser.Said test with prefixed words 'stone hammer' (12)");
+    Parser.ParseText("take stone");
+    tap.nok(Parser.Said(saidWords), "Parser.Said test with prefixed words 'stone hammer' (13)");
+    Parser.ParseText("take stone hammer");
+    tap.ok(Parser.Said(saidWords), "Parser.Said test with prefixed words 'stone hammer' (14)");
+  }
+
+  // Test Parser.Said with multi-word synonym
+  {
+    String saidWords = "take blue-key";
+
+    Parser.ParseText("take blue key");
+    tap.ok(Parser.Said(saidWords), "Parser.Said test with multi-word synonym 'blue-key' (1)");
+    Parser.ParseText("take blue-key");
+    tap.ok(Parser.Said(saidWords), "Parser.Said test with multi-word synonym 'blue-key' (2)");
+
+    saidWords = "take blue key";
+
+    Parser.ParseText("take blue key");
+    tap.ok(Parser.Said(saidWords), "Parser.Said test with multi-word synonym 'blue-key' (3)");
+    Parser.ParseText("take blue-key");
+    tap.ok(Parser.Said(saidWords), "Parser.Said test with multi-word synonym 'blue-key' (4)");
+
+    saidWords = "take blue-key,blue key";
+
+    Parser.ParseText("take blue key");
+    tap.ok(Parser.Said(saidWords), "Parser.Said test with multi-word synonym 'blue-key' (5)");
+    Parser.ParseText("take blue-key");
+    tap.ok(Parser.Said(saidWords), "Parser.Said test with multi-word synonym 'blue-key' (6)");
+  }
+
+  // Test Parser.Said with one multi-word
+  {
+    String saidWords = "take red key";
+    TestParserSaid(saidWords, "take tablet", 0);
+    TestParserSaid(saidWords, "take brick", 0);
+    TestParserSaid(saidWords, "take red key", 1);
+    TestParserSaid(saidWords, "take blue key", 0);
+
+    saidWords = "take tablet,red key";
+    TestParserSaid(saidWords, "take tablet", 1);
+    TestParserSaid(saidWords, "take brick", 0);
+    TestParserSaid(saidWords, "take red key", 1);
+    TestParserSaid(saidWords, "take blue key", 0);
+
+    saidWords = "take red key,tablet";
+    TestParserSaid(saidWords, "take tablet", 1);
+    TestParserSaid(saidWords, "take brick", 0);
+    TestParserSaid(saidWords, "take red key", 1);
+    TestParserSaid(saidWords, "take blue key", 0);
+
+    saidWords = "take tablet,brick,red key";
+    TestParserSaid(saidWords, "take tablet", 1);
+    TestParserSaid(saidWords, "take brick", 1);
+    TestParserSaid(saidWords, "take red key", 1);
+    TestParserSaid(saidWords, "take blue key", 0);
+
+    saidWords = "take tablet,red key,brick";
+    TestParserSaid(saidWords, "take tablet", 1);
+    TestParserSaid(saidWords, "take brick", 1);
+    TestParserSaid(saidWords, "take red key", 1);
+    TestParserSaid(saidWords, "take blue key", 0);
+
+    saidWords = "take red key,tablet,brick";
+    TestParserSaid(saidWords, "take tablet", 1);
+    TestParserSaid(saidWords, "take brick", 1);
+    TestParserSaid(saidWords, "take red key", 1);
+    TestParserSaid(saidWords, "take blue key", 0);
+  }
+
+  // Test Parser.Said with two multi-words
+  {
+    String saidWords = "take blue key,red key";
+    TestParserSaid(saidWords, "take tablet", 0);
+    TestParserSaid(saidWords, "take brick", 0);
+    TestParserSaid(saidWords, "take red key", 1);
+    TestParserSaid(saidWords, "take blue key", 1);
+
+    saidWords = "take tablet,blue key,red key";
+    TestParserSaid(saidWords, "take tablet", 1);
+    TestParserSaid(saidWords, "take brick", 0);
+    TestParserSaid(saidWords, "take red key", 1);
+    TestParserSaid(saidWords, "take blue key", 1);
+
+    saidWords = "take blue key,tablet,red key";
+    TestParserSaid(saidWords, "take tablet", 1);
+    TestParserSaid(saidWords, "take brick", 0);
+    TestParserSaid(saidWords, "take red key", 1);
+    TestParserSaid(saidWords, "take blue key", 1);
+
+    saidWords = "take blue key,red key,tablet";
+    TestParserSaid(saidWords, "take tablet", 1);
+    TestParserSaid(saidWords, "take brick", 0);
+    TestParserSaid(saidWords, "take red key", 1);
+    TestParserSaid(saidWords, "take blue key", 1);
+  }  
 
   tap.Comment("end Parser tests");
 }

--- a/ags3/auto-test/test-parser.asc
+++ b/ags3/auto-test/test-parser.asc
@@ -7,7 +7,7 @@ int GetTestParserCount()
 void TestParserSaid(const string saidWords, const string inputText, int expectedResult)
 {
     Parser.ParseText(inputText);
-    String testName = String.Format("TestParserSaid: Said() '%s' with ParseText() '%s' should be %d",  saidWords, inputText, expectedResult);
+    String testName = String.Format("TestParserSaid: Said() '%s' with ParseText() '%s' should be %d", saidWords, inputText, expectedResult);
 
     if(expectedResult)
       tap.ok(Parser.Said(saidWords), testName);
@@ -15,12 +15,15 @@ void TestParserSaid(const string saidWords, const string inputText, int expected
       tap.nok(Parser.Said(saidWords), testName);
 
     // test with extra content at the end
-    String extendedText = String.Format("%s rol", inputText);
+    String extendedWords = String.Format("%s rol", saidWords);
+    String extendedText = String.Format("%s please", inputText);
     Parser.ParseText(extendedText);
+    testName = String.Format("TestParserSaid: Said() '%s' with ParseText() '%s' should be %d", extendedWords, extendedText, expectedResult);
+
     if(expectedResult)
-      tap.ok(Parser.Said(saidWords), testName);
+      tap.ok(Parser.Said(extendedWords), testName);
     else
-      tap.nok(Parser.Said(saidWords), testName);
+      tap.nok(Parser.Said(extendedWords), testName);
 }
 
 void TestParser()

--- a/ags3/auto-test/test-parser.asc
+++ b/ags3/auto-test/test-parser.asc
@@ -1,7 +1,7 @@
 // Test Parser Module Script
 int GetTestParserCount()
 {
-  return 12 + 14 /* prefixed tests */ + 6 /* synonyms */ + 48 /* one multi-word */ + 32 /* two multi-words */;
+  return 12 + 14 /* prefixed tests */ + 8 /* synonyms */ + 48 /* one multi-word */ + 32 /* two multi-words */;
 }
 
 void TestParserSaid(const string saidWords, const string inputText, int expectedResult)
@@ -154,7 +154,14 @@ void TestParser()
     tap.ok(Parser.Said(saidWords), "Parser.Said test with multi-word synonym 'blue-key' (5)");
     Parser.ParseText("take blue-key");
     tap.ok(Parser.Said(saidWords), "Parser.Said test with multi-word synonym 'blue-key' (6)");
-  }
+
+    saidWords = "take blue key,blue-key";
+
+    Parser.ParseText("take blue key");
+    tap.ok(Parser.Said(saidWords), "Parser.Said test with multi-word synonym 'blue-key' (7)");
+    Parser.ParseText("take blue-key");
+    tap.ok(Parser.Said(saidWords), "Parser.Said test with multi-word synonym 'blue-key' (8)");
+}
 
   // Test Parser.Said with one multi-word
   {


### PR DESCRIPTION
I've added a range of tests for using multi-words in the parser; apologies if it looks a bit overkill but I think the issues around the parsing function we've recently found warrant a comprehensive approach. These tests need current master to fully pass.